### PR TITLE
Pass `createSession` to native `getSession` call

### DIFF
--- a/core/src/main/java/org/pac4j/jax/rs/servlet/pac4j/ServletSessionStore.java
+++ b/core/src/main/java/org/pac4j/jax/rs/servlet/pac4j/ServletSessionStore.java
@@ -20,95 +20,79 @@ public class ServletSessionStore implements SessionStore {
 
     public static final ServletSessionStore INSTANCE = new ServletSessionStore();
 
-    protected HttpSession httpSession;
-
     protected ServletSessionStore() {}
 
-    protected ServletSessionStore(final HttpSession httpSession) {
-        this.httpSession = httpSession;
-    }
-
-    public HttpSession getHttpSession(final WebContext context, final boolean createSession) {
+    public Optional<HttpSession> getNativeSession(final WebContext context, final boolean createSession) {
         assert context instanceof ServletJaxRsContext;
-        return ((ServletJaxRsContext) context).getRequest().getSession(createSession);
+
+        final HttpSession nativeSession = ((ServletJaxRsContext) context).getRequest().getSession(createSession);
+        return Optional.ofNullable(nativeSession);
     }
 
     @Override
     public Optional<Object> get(final WebContext context, final String key) {
-        final HttpSession session = getHttpSession(context, false);
-
-        if (session == null) {
-            return Optional.empty();
-        }
-
-        return Optional.ofNullable(session.getAttribute(key));
+        return getNativeSession(context, false)
+            .map(it -> it.getAttribute(key));
     }
 
     @Override
     public void set(final WebContext context, final String key, final Object value) {
-        final HttpSession session = getHttpSession(context, value != null);
-
-        if (session != null) {
-            if (value == null) {
-                session.removeAttribute(key);
-            } else {
-                session.setAttribute(key, value);
-            }
-        }
+        getNativeSession(context, value != null)
+            .ifPresent(it -> {
+                if (value == null) {
+                    it.removeAttribute(key);
+                } else {
+                    it.setAttribute(key, value);
+                }
+            });
     }
 
     @Override
     public boolean destroySession(final WebContext context) {
-        final HttpSession session = getHttpSession(context, false);
-
-        if (session != null) {
-            session.invalidate();
-
-            return true;
-        }
-
-        return false;
+        return getNativeSession(context, false)
+            .map(it -> {
+                it.invalidate();
+                return true;
+            })
+            .orElse(false);
     }
 
     @Override
     public Optional<Object> getTrackableSession(final WebContext context) {
-        return Optional.ofNullable(getHttpSession(context, false));
+        return Optional.ofNullable(getNativeSession(context, false));
     }
 
     @Override
     public boolean renewSession(final WebContext context) {
-        final HttpSession session = getHttpSession(context, false);
+        return getNativeSession(context, false)
+            .map(it -> {
+                final Map<String, Object> attributes = new HashMap<>();
+                Collections.list(it.getAttributeNames()).forEach(k -> attributes.put(k, it.getAttribute(k)));
 
-        if (session != null) {
-            final Map<String, Object> attributes = new HashMap<>();
-            Collections.list(session.getAttributeNames()).forEach(k -> attributes.put(k, session.getAttribute(k)));
+                it.invalidate();
 
-            session.invalidate();
+                // let's recreate the session from zero, the previous becomes
+                // generally unusable depending on the servlet implementation
+                getNativeSession(context, true)
+                    .ifPresent(newSession -> attributes.forEach(newSession::setAttribute));
 
-            // let's recreate the session from zero, the previous becomes
-            // generally unusable depending on the servlet implementation
-            final HttpSession newSession = getHttpSession(context, true);
-            attributes.forEach(newSession::setAttribute);
-
-            return true;
-        }
-
-        return false;
+                return true;
+            })
+            .orElse(false);
     }
 
     @Override
-    public Optional<SessionStore> buildFromTrackableSession(final WebContext context, final  Object trackableSession) {
+    public Optional<SessionStore> buildFromTrackableSession(final WebContext context, final Object trackableSession) {
         return Optional.of(new ServletSessionStore() {
             @Override
-            public HttpSession getHttpSession(WebContext context, boolean createSession) {
-                return (HttpSession) trackableSession;
+            public Optional<HttpSession> getNativeSession(WebContext context, boolean createSession) {
+                return Optional.of((HttpSession) trackableSession);
             }
         });
     }
 
     @Override
     public Optional<String> getSessionId(final WebContext context, final boolean createSession) {
-        HttpSession session = getHttpSession(context, createSession);
-        return (session != null) ? Optional.of(session.getId()) : Optional.empty();
+        return getNativeSession(context, createSession).map(HttpSession::getId);
     }
 }

--- a/core/src/main/java/org/pac4j/jax/rs/servlet/pac4j/ServletSessionStore.java
+++ b/core/src/main/java/org/pac4j/jax/rs/servlet/pac4j/ServletSessionStore.java
@@ -28,7 +28,7 @@ public class ServletSessionStore implements SessionStore {
         this.httpSession = httpSession;
     }
 
-    public HttpSession getHttpSession(WebContext context, boolean createSession) {
+    public HttpSession getHttpSession(final WebContext context, final boolean createSession) {
         assert context instanceof ServletJaxRsContext;
         return ((ServletJaxRsContext) context).getRequest().getSession(createSession);
     }
@@ -58,7 +58,7 @@ public class ServletSessionStore implements SessionStore {
     }
 
     @Override
-    public boolean destroySession(WebContext context) {
+    public boolean destroySession(final WebContext context) {
         final HttpSession session = getHttpSession(context, false);
 
         if (session != null) {
@@ -71,12 +71,12 @@ public class ServletSessionStore implements SessionStore {
     }
 
     @Override
-    public Optional<Object> getTrackableSession(WebContext context) {
+    public Optional<Object> getTrackableSession(final WebContext context) {
         return Optional.ofNullable(getHttpSession(context, false));
     }
 
     @Override
-    public boolean renewSession(WebContext context) {
+    public boolean renewSession(final WebContext context) {
         final HttpSession session = getHttpSession(context, false);
 
         if (session != null) {
@@ -97,7 +97,7 @@ public class ServletSessionStore implements SessionStore {
     }
 
     @Override
-    public Optional<SessionStore> buildFromTrackableSession(WebContext context, Object trackableSession) {
+    public Optional<SessionStore> buildFromTrackableSession(final WebContext context, final  Object trackableSession) {
         return Optional.of(new ServletSessionStore() {
             @Override
             public HttpSession getHttpSession(WebContext context, boolean createSession) {
@@ -107,7 +107,7 @@ public class ServletSessionStore implements SessionStore {
     }
 
     @Override
-    public Optional<String> getSessionId(WebContext context, boolean createSession) {
+    public Optional<String> getSessionId(final WebContext context, final boolean createSession) {
         HttpSession session = getHttpSession(context, createSession);
         return (session != null) ? Optional.of(session.getId()) : Optional.empty();
     }

--- a/core/src/main/java/org/pac4j/jax/rs/servlet/pac4j/ServletSessionStore.java
+++ b/core/src/main/java/org/pac4j/jax/rs/servlet/pac4j/ServletSessionStore.java
@@ -98,7 +98,7 @@ public class ServletSessionStore implements SessionStore {
 
     @Override
     public Optional<SessionStore> buildFromTrackableSession(WebContext context, Object trackableSession) {
-        return Optional.ofNullable(new ServletSessionStore() {
+        return Optional.of(new ServletSessionStore() {
             @Override
             public HttpSession getHttpSession(WebContext context, boolean createSession) {
                 return (HttpSession) trackableSession;


### PR DESCRIPTION
Instead of catching an `IllegalStateException` in the `getHttpSession` method, pass the `createSession` parameter. This should avoid creating a session for use cases where we do not want to do so.

I also updated the method name to `getNativeSession` which more closely aligns with other `SessionStore` implementations, for example [`JEESessionStore`](https://github.com/pac4j/pac4j/blob/e9bd24f8a6773df2a7698fea79fa37d1e24be31f/pac4j-jakartaee/src/main/java/org/pac4j/jee/context/session/JEESessionStore.java#L51-L61)